### PR TITLE
fix: check if UTI exists [Fixes a crash if UTI is null on Mac M1 simu…

### DIFF
--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -110,7 +110,11 @@ RCT_EXPORT_METHOD(getFileInfo:(NSString *)path resolve:(RCTPromiseResolveBlock)r
 - (NSString *)guessMIMETypeFromFileName: (NSString *)fileName {
     CFStringRef UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)[fileName pathExtension], NULL);
     CFStringRef MIMEType = UTTypeCopyPreferredTagWithClass(UTI, kUTTagClassMIMEType);
-    CFRelease(UTI);
+
+    if (UTI) {
+        CFRelease(UTI);
+    }
+
     if (!MIMEType) {
         return @"application/octet-stream";
     }


### PR DESCRIPTION
…lators]

From: https://github.com/Vydia/react-native-background-upload/pull/272

Fixes a crash if UTI is null on Mac M1 simulators:


