### PR TITLE
Add API to get all scheduled uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,18 @@ Returns an [EventSubscription](https://github.com/facebook/react-native/blob/mas
 
 On Android, this setting takes effect immediately and will be applied for the next upload. On iOS, this setting will be only applied for the next NSURLSession.
 
+### getAllUploads()
+
+Retrieves all scheduled uploads and their state from system's internal database.
+
+Note that this will not give you all the uploads ever scheduled, both iOS and Android periodically prune completed(succeeded/failed/cancelled) tasks from their database. Therefore this should not be used as the primary way to check upload statuses, add your listeners via `addListener` instead. However, `getAllUploads` is particularly useful as a backup plan in case events were dropped(e.g. adding listeners too late).
+
+Returns a Promise that resolves to an array of objects containing:
+
+|Name|Type|Required|Description|
+|---|---|---|---|---|
+|`id`|string|Required|The upload ID from `startUpload`|
+|`state`|[UploadState](#uploadstate)|Required|The current state of the upload|
 
 ## Events
 
@@ -267,6 +279,17 @@ Event Data
 |Name|Type|Required|Description|
 |---|---|---|---|
 |`id`|string|Required|The ID of the upload.|
+
+## Types
+
+### UploadState
+
+|Value|Description|
+|---|---|
+|`cancelled`|The upload has been cancelled, either by OS or by using `cancelUpload`|
+|`completed`|The upload has finished, either succeeded or failed|
+|`pending`|The upload is scheduled but not active at the moment|
+|`running`|The upload is in progress|
 
 # Customizing Android Build Properties
 You may want to customize the `compileSdk, buildToolsVersion, and targetSdkVersion` versions used by this package.  For that, add this to `android/build.gradle`:

--- a/android/src/main/java/com/appfolio/uploader/ModifiedHttpUploadRequest.kt
+++ b/android/src/main/java/com/appfolio/uploader/ModifiedHttpUploadRequest.kt
@@ -42,6 +42,7 @@ abstract class ModifiedHttpUploadRequest<B : HttpUploadRequest<B>>(context: Cont
     val workManager: WorkManager = WorkManager.getInstance(context)
     val uploadRequest = OneTimeWorkRequest.Builder(UploadWorker::class.java)
     uploadRequest.shouldLimitNetwork(limitNetwork)
+    uploadRequest.addTag("${UploadWorker::class.java.simpleName}-$uploadId")
     uploadRequest.setData(uploadTaskParameters, notificationConfig(context, uploadId))
     workManager.enqueue(uploadRequest.build())
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,13 @@ declare module '@appfolio/react-native-upload' {
     | 'completed'
     | 'cancelled';
 
+  export enum UploadState {
+    Cancelled = 'cancelled',
+    Completed = 'completed',
+    Pending = 'pending',
+    Running = 'running',
+  }
+
   export default class Upload {
     static startUpload(
       options: UploadOptions | MultipartUploadOptions,
@@ -138,7 +145,8 @@ declare module '@appfolio/react-native-upload' {
     ): EventSubscription;
     static getFileInfo(path: string): Promise<FileInfo>;
     static cancelUpload(uploadId: uploadId): Promise<boolean>;
-    static canSuspendIfBackground();
-    static shouldLimitNetwork(limit: boolean);
+    static canSuspendIfBackground(): void;
+    static shouldLimitNetwork(limit: boolean): void;
+    static getAllUploads(): Promise<Array<{ id: string, state: UploadState }>>;
   }
 }

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -273,6 +273,39 @@ RCT_EXPORT_METHOD(shouldLimitNetwork: (BOOL) limit) {
     limitNetwork = limit;
 }
 
+RCT_EXPORT_METHOD(getAllUploads:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+    NSString *appGroup = nil;
+    [[self urlSession: appGroup] getTasksWithCompletionHandler:^(NSArray *dataTasks, NSArray *uploadTasks, NSArray *downloadTasks) {
+        NSMutableArray *uploads = [NSMutableArray new];
+        for (NSURLSessionUploadTask *uploadTask in uploadTasks) {
+            NSString *state;
+            switch (uploadTask.state) {
+            case NSURLSessionTaskStateRunning:
+                state = @"running";
+                break;
+            case NSURLSessionTaskStateSuspended:
+                state = @"pending";
+                break;
+            case NSURLSessionTaskStateCanceling:
+                state = @"cancelled";
+                break;
+            case NSURLSessionTaskStateCompleted:
+                state = @"completed";
+                break;
+            }
+            
+            NSDictionary *upload = @{
+                @"id" : uploadTask.taskDescription,
+                @"state" : state
+            };
+            [uploads addObject:upload];
+        }
+        resolve(uploads);
+    }];
+}
+
 - (NSData *)createBodyWithBoundary:(NSString *)boundary
             path:(NSString *)path
             parameters:(NSDictionary *)parameters

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -11,7 +11,6 @@
 RCT_EXPORT_MODULE();
 
 @synthesize bridge = _bridge;
-static int uploadId = 0;
 static VydiaRNFileUploader* staticInstance = nil;
 static NSString *BACKGROUND_SESSION_ID = @"ReactNativeBackgroundUpload";
 NSMutableDictionary *_responsesData;
@@ -165,12 +164,6 @@ RCT_EXPORT_METHOD(getFileInfo:(NSString *)path resolve:(RCTPromiseResolveBlock)r
  */
 RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 {
-    int thisUploadId;
-    @synchronized(self.class)
-    {
-        thisUploadId = uploadId++;
-    }
-
     NSString *uploadUrl = options[@"url"];
     __block NSString *fileURI = options[@"path"];
     NSString *method = options[@"method"] ?: @"POST";
@@ -235,7 +228,8 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
             uploadTask = [[self urlSession: appGroup] uploadTaskWithRequest:request fromFile:[NSURL URLWithString: fileURI]];
         }
 
-        uploadTask.taskDescription = customUploadId ? customUploadId : [NSString stringWithFormat:@"%i", thisUploadId];
+        NSString *uploadId = customUploadId ? customUploadId : [[NSUUID UUID] UUIDString];
+        uploadTask.taskDescription = uploadId;
 
         [uploadTask resume];
         resolve(uploadTask.taskDescription);

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -54,7 +54,7 @@ BOOL limitNetwork = NO;
     // JS side is ready to receive events; create the background url session if necessary
     // iOS will then deliver the tasks completed while the app was dead (if any)
     NSString *appGroup = nil;
-    double delayInSeconds = 30;
+    double delayInSeconds = 5;
     dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, delayInSeconds * NSEC_PER_SEC);
     dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
         [self urlSession:appGroup];

--- a/src/index.js
+++ b/src/index.js
@@ -129,6 +129,17 @@ export const shouldLimitNetwork = (limit: boolean) => {
   NativeModule.shouldLimitNetwork(limit);
 };
 
+export const UploadState = {
+  Cancelled: 'cancelled',
+  Completed: 'completed',
+  Pending: 'pending',
+  Running: 'running',
+};
+
+export const getAllUploads = () => {
+  return NativeModule.getAllUploads();
+};
+
 export default {
   startUpload,
   cancelUpload,
@@ -136,4 +147,5 @@ export default {
   getFileInfo,
   canSuspendIfBackground,
   shouldLimitNetwork,
+  getAllUploads,
 };


### PR DESCRIPTION
# Summary

Add `getAllUploads` API to retrieve all scheduled uploads that are in the system's internal database along with their status.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅   |
| Android |    ✅   |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS)
- [ ] I've added Detox End-to-End Test(s)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
