### PR TITLE
Fix getAllUploads for Android

### DIFF
--- a/android/src/main/java/com/appfolio/uploader/ModifiedHttpUploadRequest.kt
+++ b/android/src/main/java/com/appfolio/uploader/ModifiedHttpUploadRequest.kt
@@ -39,6 +39,7 @@ abstract class ModifiedHttpUploadRequest<B : HttpUploadRequest<B>>(context: Cont
           "already running task. You're trying to use the same ID for multiple uploads."
     }
 
+    started = true
     val workManager: WorkManager = WorkManager.getInstance(context)
     val uploadRequest = OneTimeWorkRequest.Builder(UploadWorker::class.java)
     uploadRequest.shouldLimitNetwork(limitNetwork)

--- a/index.d.ts
+++ b/index.d.ts
@@ -119,6 +119,8 @@ declare module '@appfolio/react-native-upload' {
     Running = 'running',
   }
 
+  export type SystemUploadStates = Array<{ id: string, state: UploadState }>;
+
   export default class Upload {
     static startUpload(
       options: UploadOptions | MultipartUploadOptions,
@@ -147,6 +149,6 @@ declare module '@appfolio/react-native-upload' {
     static cancelUpload(uploadId: uploadId): Promise<boolean>;
     static canSuspendIfBackground(): void;
     static shouldLimitNetwork(limit: boolean): void;
-    static getAllUploads(): Promise<Array<{ id: string, state: UploadState }>>;
+    static getAllUploads(): Promise<SystemUploadStates>;
   }
 }


### PR DESCRIPTION
Fix getAllUploads method for Android: ignore "success" and "failed" states from WorkManager, and instead use UploadManager.taskList to get running upload tasks

