### PR TITLE
Use custom upload ID on Android (MITM-706)

### DIFF
--- a/android/src/main/java/com/appfolio/uploader/ModifiedHttpUploadRequest.kt
+++ b/android/src/main/java/com/appfolio/uploader/ModifiedHttpUploadRequest.kt
@@ -49,4 +49,9 @@ abstract class ModifiedHttpUploadRequest<B : HttpUploadRequest<B>>(context: Cont
 
     return uploadTaskParameters.id;
   }
+
+  fun setCustomUploadID(uploadID: String) {
+    this.uploadId = uploadID
+    setUploadID(uploadID)
+  }
 }

--- a/android/src/main/java/com/appfolio/uploader/UploaderModule.kt
+++ b/android/src/main/java/com/appfolio/uploader/UploaderModule.kt
@@ -268,7 +268,7 @@ class UploaderModule(val reactContext: ReactApplicationContext) : ReactContextBa
         }
       }
       if (customUploadId != null)
-        request.setUploadID(customUploadId)
+        request.setCustomUploadID(customUploadId)
 
       val uploadId = request.startUpload()
       promise.resolve(uploadId)


### PR DESCRIPTION
### Overview

Previously on Android, `customUploadId` wasn't used throughout the upload process due to `ModifiedHttpUploadRequest` and `UploadRequest` having their own `uploadId`, and this resulted in the `completed` listener being called on a different UUID than the one given to `startUpload`.

This PR ensures that the `customUploadId` used to `startUpload` is the one called in the listeners.
