### PR TITLE
[Android] Handle race condition that fails some upload failure retries [MITM-842]

### DIFF
--- a/android/src/main/java/com/appfolio/work/TaskCompletionNotifier.kt
+++ b/android/src/main/java/com/appfolio/work/TaskCompletionNotifier.kt
@@ -34,6 +34,7 @@ class TaskCompletionNotifier : UploadTaskObserver {
       notificationConfig: UploadNotificationConfig,
       exception: Throwable
   ) {
+    UploadManager.taskFailed(info.uploadId)
   }
 
   override fun onCompleted(

--- a/android/src/main/java/com/appfolio/work/UploadManager.kt
+++ b/android/src/main/java/com/appfolio/work/UploadManager.kt
@@ -88,6 +88,15 @@ class UploadManager {
     }
 
     /**
+     * Called by each task when it errors out.
+     * @param uploadId the uploadID of the task with error
+     */
+    @Synchronized
+    fun taskFailed(uploadId: String) {
+      uploadTasksMap.remove(uploadId)
+    }
+
+    /**
      * Called by each task when it is completed (either successfully, with an error or due to
      * user cancellation).
      * @param uploadId the uploadID of the finished task


### PR DESCRIPTION
There's a race condition that happens during retries on Android:
onError() --> notifies app
onCompleted() --> is called after onError() and this is when UploadManager in rn-upload removes the entry from map.

If the app retries before onCompleted() is called, then the retry fails due to UploadManager thinking it's a duplicate upload (since the map still has the upload task).

So, to fix this, this PR removes the task from the map onError() in UploadManager.

