### PR TITLE
Add CODEOWNERS (@appfolio/resident-mobile)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @appfolio/resident-mobile


### PR DESCRIPTION
Part of the repo-ownership work for the security initiative: every active repo in the org needs a CODEOWNERS owner so vulnerability alerts route to a real team instead of nowhere.

**Owner:** @appfolio/resident-mobile

**No catalog-info.yaml here on purpose.** This package publishes to a registry — `package.json` sets `publishConfig.registry: https://npm.pkg.github.com/` and the package is scoped as `@appfolio/react-native-upload` — which means the Developer Portal ingests it automatically from `package.json`. Hand-authoring a `catalog-info.yaml` would stack a duplicate on top of the auto-ingested entity.

Adding CODEOWNERS is what actually fixes ownership: the portal resolves ownership from CODEOWNERS first. Any further shaping of the catalog entry belongs in `package.json` metadata, per the npm packages how-to.

Note this repo is a fork of `Vydia/react-native-background-upload`.