### PR TITLE
chore: add JFrog registry option, following react-gears public-repo pattern

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -19,6 +19,9 @@ jobs:
       with:
         node-version: 12
 
+    - name: Use public registry config
+      run: cp .npmrc-public .npmrc
+
     - name: Release to NPM
       if: github.ref == 'refs/heads/master'
       env:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,6 +16,9 @@ jobs:
       with:
         node-version: 12
 
+    - name: use public registry config
+      run: cp .npmrc-public .npmrc
+
     - name: install node_modules
       run: yarn install --frozen-lockfile
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,8 @@
+registry=https://appfolio.jfrog.io/artifactory/api/npm/appfolio-apm-mobile-npm/
+//appfolio.jfrog.io/artifactory/api/npm/appfolio-apm-mobile-npm/:_authToken=${JFROG_ACCESS_TOKEN}
+always-auth=true
+
 @appfolio:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GITHUB_NPM_TOKEN}
 
-always-auth=true
 cache=tmp/node_cache

--- a/.npmrc-public
+++ b/.npmrc-public
@@ -1,0 +1,6 @@
+registry=https://registry.npmjs.org/
+
+@appfolio:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_NPM_TOKEN}
+
+cache=tmp/node_cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,3 +6,26 @@ a full-stack (React Native + Express.js) example app, which you can fork and
 alter to reproduce your bug:
 
 [ReactNativeBackgroundUploadExample](https://github.com/Vydia/ReactNativeBackgroundUploadExample)
+
+## Development
+
+The repo has two install configurations so that both AppFolio and non-AppFolio
+contributors can build it.
+
+**AppFolio members** — the default `.npmrc` routes through AppFolio's JFrog
+mirror. Set `JFROG_ACCESS_TOKEN` in your environment (available from your JFrog
+profile) and run:
+
+```
+yarn install
+```
+
+**Non-AppFolio contributors** — use the public npm registry:
+
+```
+cp .npmrc-public .npmrc
+yarn install
+```
+
+CI uses the public configuration; publishing goes to GitHub Packages via
+`GITHUB_TOKEN` and does not require JFrog access.


### PR DESCRIPTION
## Summary

Adopts the public-repo registry pattern from [appfolio/react-gears#1287](https://github.com/appfolio/react-gears/pull/1287): a JFrog-backed default for AppFolio members and a public-registry fallback for external contributors and for CI. Because this repo is public, workflows must not require secrets, and non-AppFolio contributors must still be able to build it.

## Changes

- **`.npmrc`** — default registry set to JFrog (`appfolio-apm-mobile-npm`) with `${JFROG_ACCESS_TOKEN}` auth. Used by AppFolio members locally.
- **`.npmrc-public`** (new) — public npm registry, no auth. Used by external contributors and by CI.
- **`.github/workflows/node.yml`** — `cp .npmrc-public .npmrc` before `yarn install`.
- **`.github/workflows/deploy-release.yml`** — same swap; publish goes to GitHub Packages via `GITHUB_TOKEN` (per existing `publishConfig`), so no JFrog token is needed in CI.
- **`CONTRIBUTING.md`** — documents both install paths.

## Why not touch `.yarnrc` / `yarn.lock`?

This repo has no `@appfolio/*` runtime deps (the `@appfolio/*` scope is only its own package name), so every tarball URL in `yarn.lock` already points at the public `registry.yarnpkg.com`. Yarn 1 fetches tarballs directly from those baked-in URLs — the `.npmrc` registry setting only affects metadata lookups. That means `yarn install --frozen-lockfile` succeeds under either config without rewriting the lockfile.

## Test plan

- [x] `yarn install --frozen-lockfile` succeeds with `.npmrc` (JFrog, with `JFROG_ACCESS_TOKEN` set)
- [x] `yarn install --frozen-lockfile` succeeds with `.npmrc-public` copied over `.npmrc`
- [ ] CI green